### PR TITLE
Update utils.R

### DIFF
--- a/R/tweets_lookup
+++ b/R/tweets_lookup
@@ -1,0 +1,46 @@
+tweets_lookup <-
+  function(ids,
+           bearer_token = get_bearer(),
+           data_path = NULL,
+           context_annotations = FALSE,
+           bind_tweets = TRUE,
+           verbose = TRUE,
+           errors = FALSE){    
+    
+    # Building parameters for get_tweets()
+    params <- list(
+      tweet.fields = "attachments,author_id,conversation_id,created_at,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,source,text,withheld", 
+      user.fields = "created_at,description,entities,id,location,name,pinned_tweet_id,profile_image_url,protected,public_metrics,url,username,verified,withheld", 
+      expansions = "author_id,entities.mentions.username,geo.place_id,in_reply_to_user_id,referenced_tweets.id,referenced_tweets.id.author_id", 
+      place.fields = "contained_within,country,country_code,full_name,geo,id,name,place_type"
+    )
+    if (context_annotations) {
+      params[["tweet.fields"]] <- "attachments,author_id,context_annotations,conversation_id,created_at,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,source,text,withheld"
+    }
+    # loop through x in batches of 100 IDs
+    new_df <- data.frame()
+    for (i in 1:ceiling(length(ids) / 100)){
+      batch <- ids[((i-1)*100+1):min(length(ids),(i*100))]
+      endpoint_url <- sprintf('https://api.twitter.com/2/tweets?ids=%s', paste0(batch, collapse = ","))
+      
+      # Get tweets
+      .vcat(verbose, "Batch", i, "out of", ceiling(length(ids) / 100),": ids", head(batch, n = 1), "to", tail(batch, n = 1), "\n")
+      new_rows <- get_tweets_with_errors(params = params, endpoint_url = endpoint_url, n = Inf, file = NULL, bearer_token = bearer_token, 
+                             export_query = FALSE, data_path = data_path, bind_tweets = bind_tweets, verbose = F, errors = errors)
+      if (errors){
+        .vcat(verbose, "Retrieved", nrow(dplyr::filter(new_rows, is.na(error))), "out of", length(batch), "\n" , 
+              "Errors:", nrow(dplyr::filter(new_rows, !is.na(error))), "\n" )
+      } else {
+        .vcat(verbose, "Retrieved", nrow(new_rows), "out of", length(batch), "\n")}
+      if (nrow(new_rows) > 0) {
+        #  new_rows$from_tweet_id <- batch[batch %in% new_rows$id]
+        new_df <- dplyr::bind_rows(new_df, new_rows) # add new rows
+      }
+      if (errors) {
+      .vcat(verbose, "Total Tweets:", nrow(dplyr::filter(new_df, is.na(error))), "\n")
+      } else {
+      .vcat(verbose, "Total Tweets:", nrow(new_df), "\n")
+      }
+    }
+    new_df # return the df
+  }

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,8 @@ make_query <- function(url, params, bearer_token, max_error = 4, verbose = TRUE)
   jsonlite::fromJSON(httr::content(r, "text"))
 }
 
-get_tweets <- function(params, endpoint_url, page_token_name = "next_token", n, file, bearer_token, data_path, export_query, bind_tweets, verbose) {
+get_tweets <- function(params, endpoint_url, page_token_name = "next_token", n, file, bearer_token, data_path, export_query, bind_tweets, verbose, errors) {
+  # New: the errors parameter allows to optionally retrieve tweets that throw an error, with the according error description. Currently, only the id-level errors are added to the bound data.frame. All errors are contained in the error_ json files when path is used, however
   
   # Check file storage conditions
   create_storage_dir(data_path = data_path, export_query = export_query, built_query = params[["query"]], start_tweets = params[["start_time"]], end_tweets = params[["end_time"]], verbose = verbose)
@@ -48,13 +49,21 @@ get_tweets <- function(params, endpoint_url, page_token_name = "next_token", n, 
     if (is.null(data_path)) {
       # if data path is null, generate data.frame object within loop
       df.all <- dplyr::bind_rows(df.all, df$data)
+      if (errors) { # error catcher
+        df.errors <- df$errors %>% dplyr::filter(parameter == "ids") %>% dplyr::select(resource_id, title) %>% rename(id = resource_id, error = title)
+        df.all <- dplyr::bind_rows(df.all, df.errors)
+      }
     }
     if (!is.null(data_path) & is.null(file) & !bind_tweets) {
-      df_to_json(df, data_path)
+      df_to_json(df, data_path, errors) # piping error options to df_to_json
     }
     if (!is.null(data_path)) {
-      df_to_json(df, data_path)
+      df_to_json(df, data_path, errors) # piping error options to df_to_json
       df.all <- dplyr::bind_rows(df.all, df$data) #and combine new data with old within function
+      if (errors) { # error catcher
+        df.errors <- df$errors %>% dplyr::filter(parameter == "ids") %>% dplyr::select(resource_id, title) %>% rename(id = resource_id, error = title)
+        df.all <- dplyr::bind_rows(df.all, df.errors)
+      }
     }
     next_token <- df$meta$next_token #this is NULL if there are no pages left
     if (!is.null(next_token)) {
@@ -144,13 +153,16 @@ create_data_dir <- function(data_path, verbose = TRUE){
   invisible(data_path)  
 }
 
-df_to_json <- function(df, data_path){
+df_to_json <- function(df, data_path, errors){
   # check input
   # if data path is supplied and file name given, generate data.frame object within loop and JSONs
   jsonlite::write_json(df$data,
                        file.path(data_path, paste0("data_", df$data$id[nrow(df$data)], ".json")))
   jsonlite::write_json(df$includes,
                        file.path(data_path, paste0("users_", df$data$id[nrow(df$data)], ".json")))
+    if (errors) { # error catcher
+    jsonlite::write_json(df$errors,
+                         file.path(data_path, paste0("errors_", df$data$id[nrow(df$data)], ".json")))
 }
 
 create_storage_dir <- function(data_path, export_query, built_query, start_tweets, end_tweets, verbose){


### PR DESCRIPTION
Added a function to access the Tweets Lookup endpoint of the Twitter API v2, tweets_lookup. This is especially useful when looking to rehydrate tweet datasets. In order to track errors in the process (i.e., which and why tweets could not be rehydrated), optional error tracking was implemented into the get_tweets() and df_to_json() was implemented. Currently, this option is only implemented into tweets_lookup, but may prove useful for other applications